### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <br />
 
-**picklevw** (pronunced *pickleview*) is a simple Python web application, designed to read and display pickle files
+**picklevw** (pronounced *pickleview*) is a simple Python web application, designed to read and display pickle files
 using `pandas` and `streamlit`.
 
 Try it live on [picklevw.streamlit.app](https://picklevw.streamlit.app)


### PR DESCRIPTION
## Summary
- fix a typo in README: `pronunced` -> `pronounced`

## Testing
- `grep -n pronounced README.md`

------
https://chatgpt.com/codex/tasks/task_e_6865a0f5fe5883238b51051e06484252