### PR TITLE
Show generic error for file access/decompression failures

### DIFF
--- a/src/picklevw.py
+++ b/src/picklevw.py
@@ -148,6 +148,7 @@ class PickleViewerApp:
             st.error(str(err))
             st.stop()
         except (IOError, OSError) as io_err:
+            st.error(cfg.MESSAGES["GENERIC_LOAD_ERROR"])
             if cfg.CONFIG["DEBUG_MODE"]:
                 st.error(f"File access error: {io_err}")
         except Exception as ex:

--- a/tests/test_picklevw.py
+++ b/tests/test_picklevw.py
@@ -70,6 +70,19 @@ def test_process_file_unsafe_exception(mock_st, app):
         mock_st.stop.assert_called_once()
 
 
+
+
+@patch("src.picklevw.st")
+@patch("src.picklevw.cfg")
+@patch("src.picklevw.PickleLoader", side_effect=OSError("bad gzip stream"))
+def test_process_file_oserror_shows_generic_error(mock_loader, mock_cfg, mock_st, app):
+    mock_cfg.CONFIG = {"DEBUG_MODE": False}
+    mock_cfg.MESSAGES = {"GENERIC_LOAD_ERROR": "Could not load file"}
+
+    app.process_file(MagicMock(), allow_unsafe_file=False)
+
+    mock_st.error.assert_called_once_with("Could not load file")
+
 @patch("src.picklevw.st")
 @patch("src.picklevw.cfg")
 @patch.object(PickleViewerApp, "upload_file", return_value=None)


### PR DESCRIPTION
### Motivation
- File access/decompression failures (`IOError`/`OSError`) could be swallowed in `process_file`, leaving users without any feedback when uploads failed.
- A visible generic error should be shown to users while preserving detailed diagnostics in `DEBUG_MODE`.

### Description
- Always show the user-facing generic load error by calling `st.error(cfg.MESSAGES["GENERIC_LOAD_ERROR"])` in the `except (IOError, OSError)` branch of `PickleViewerApp.process_file` in `src/picklevw.py`.
- Added a regression test `test_process_file_oserror_shows_generic_error` to `tests/test_picklevw.py` that simulates an `OSError` from `PickleLoader` and asserts the generic error is shown.
- Kept existing debug behavior so `DEBUG_MODE` still surfaces low-level file access details via `st.error`/`st.exception` when enabled.

### Testing
- Ran `pytest -q`, and the test suite passed successfully (all tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdac87b22483239745712736d54dbb)